### PR TITLE
Fix crash CXProviderDelegateProxy.

### DIFF
--- a/Sources/RxCallKit/CXProvider+Rx.swift
+++ b/Sources/RxCallKit/CXProvider+Rx.swift
@@ -12,18 +12,18 @@ import RxSwift
 import RxCocoa
 
 @available(iOS 10.0, macCatalyst 13, *)
-extension CXProvider: HasDelegate {
-	
-	public typealias Delegate = CXProviderDelegate
-	
-	public var delegate: Delegate? {
-		get {
-			value(forKey: "delegate") as? Delegate
-		}
-		set(newValue) {
-			setDelegate(newValue, queue: .main)
-		}
-	}
+extension CXProvider: HasAssociatedDelegate {
+    public typealias Delegate = CXProviderDelegate
+    
+    public static var associatedDelegateKey = "CXProviderDelegateKey"
+    
+    public var delegate: Delegate? {
+        get { self.getAssociatedDelegate(forKey: &Self.associatedDelegateKey) }
+        set {
+            self.setAssociatedDelegate(newValue, forKey: &Self.associatedDelegateKey)
+            self.setDelegate(newValue, queue: .main)
+        }
+    }
 }
 
 @available(iOS 10.0, macCatalyst 13, *)

--- a/Sources/RxCallKit/HasAssociatedDelegate.swift
+++ b/Sources/RxCallKit/HasAssociatedDelegate.swift
@@ -1,0 +1,25 @@
+//
+//  AssociatedDelegate.swift
+//  
+//
+//  Created by ipagong on 2020/07/23.
+//
+
+import Foundation
+import ObjectiveC
+import RxSwift
+import RxCocoa
+
+public protocol HasAssociatedDelegate: HasDelegate {
+    static var associatedDelegateKey: String { get }
+}
+
+extension HasAssociatedDelegate {
+        func getAssociatedDelegate(forKey key: UnsafeRawPointer) -> Delegate? {
+        return objc_getAssociatedObject(self, key) as? Delegate
+    }
+    
+    func setAssociatedDelegate(_ object: Delegate?, forKey key: UnsafeRawPointer) {
+        objc_setAssociatedObject(self, key, object, .OBJC_ASSOCIATION_ASSIGN)
+    }
+}


### PR DESCRIPTION
I found a crash with `CXProviderDelegateProxy`.
so added `HasAssoicatedDelegate` and changed `getter` `setter` for delegate.
I think it would be better to use `swizzling` when called `setDelegate(_:queue:)`.